### PR TITLE
Fix Dockerfile failing to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LANGUAGE en_US:en
 
 # Install required system packages. Python 3.6 is available in IUS.
 RUN  \
-   yum -y install https://centos7.iuscommunity.org/ius-release.rpm \
+   yum -y install https://repo.ius.io/ius-release-el7.rpm \
 && yum -y update \
 && yum -y install \
 	python36u python36u-pip \


### PR DESCRIPTION
Dockerfile doesn't build since the yum repo it uses doesn't exist anymore.
Replaced with the updated one according to https://github.com/iusrepo/git216/issues/13#issuecomment-493682838